### PR TITLE
gas optimization + prettier

### DIFF
--- a/src/Loopinator.sol
+++ b/src/Loopinator.sol
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.14;
 
-function map(
-    uint256[] memory numbers,
-    function (uint256) pure returns (uint256) func
-) pure returns (uint256[] memory) {
+function map(uint256[] memory numbers, function(uint256) pure returns (uint256) func) pure returns (uint256[] memory) {
     uint256 length = numbers.length;
     uint256[] memory newNumbers = new uint256[](length);
-    uint256 i;
 
-    for (i; i < length; ) {
+    for (uint256 i; i < length; ) {
         newNumbers[i] = func(numbers[i]);
         unchecked { ++i; }
     }
@@ -17,14 +13,10 @@ function map(
     return newNumbers;
 }
 
-function forEach(
-    uint256[] memory numbers,
-    function (uint256) pure func
-) pure {
+function forEach(uint256[] memory numbers, function(uint256) pure func) pure {
     uint256 length = numbers.length;
-    uint256 i;
 
-    for (i; i < length; ) {
+    for (uint256 i; i < length; ) {
         func(numbers[i]);
         unchecked { ++i; }
     }
@@ -32,14 +24,13 @@ function forEach(
 
 function reduce(
     uint256[] memory numbers,
-    function (uint256, uint256) pure returns (uint256) func,
+    function(uint256, uint256) pure returns (uint256) func,
     uint256 initialValue
 ) pure returns (uint256) {
     uint256 result = initialValue;
     uint256 length = numbers.length;
-    uint256 i;
 
-    for (i; i < length; ) {
+    for (uint256 i; i < length; ) {
         result = func(result, numbers[i]);
         unchecked { ++i; }
     }


### PR DESCRIPTION
For loop can be gas optimized by adding uint i in for loop. 

Example and gas estimation:
```Solidity
    function loopCheck1(uint256[] memory arr) external returns (uint256[] memory) {
        gas = gasleft(); // 29863 gas
        uint length = arr.length;
        for (uint i; i < length;) {
            unchecked { ++i; }
        }
        return arr;
        gas -= gasleft();
    }
    
    function loopCheck2(uint256[] memory arr) external  returns (uint256[] memory) {
        gas = gasleft();
        uint i;
        uint length = arr.length;
        for (; i < length;) { // 29912 gas
            unchecked { ++i; }
        }
        return arr;
        gas -= gasleft();
    }
```
You can check [my article about gas optimizations](https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement)

I also used prettier. And, maybe, `memory` arrays could be changed into `calldata`.